### PR TITLE
Fix duplicated help tag

### DIFF
--- a/doc/syntaxinfo.txt
+++ b/doc/syntaxinfo.txt
@@ -108,7 +108,7 @@ g:syntaxinfo_delay                                        *g:syntaxinfo_delay*
 ==============================================================================
 Highlights                                       *nvim-syntax-info-highlights*
 
-SyntaxInfo                                                        *SyntaxInfo*
+SyntaxInfo                                                     *hl-SyntaxInfo*
 
   Default: `highlight link SyntaxInfo Comment`
 


### PR DESCRIPTION
The `SyntaxInfo` help tag is duplicated.

- Commands section
- Highlights section
